### PR TITLE
Align auto-release workflow with mcp-oauth pattern

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -8,8 +8,8 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: read
+  contents: write  # Needed to create releases and tags
+  pull-requests: read  # Needed to read PR information
 
 jobs:
   auto_release:
@@ -20,6 +20,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          # Fetch all history and tags for version calculation
           fetch-depth: 0
 
       - name: Configure Git
@@ -33,23 +34,36 @@ jobs:
         id: version
         run: |
           set -e
+          # Get the latest tag, defaulting to v0.0.0 if none exists
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null \
             || echo "v0.0.0")
+          # Remove 'v' prefix
           LATEST_VERSION=${LATEST_TAG#v}
+          # Split into major, minor, patch
           IFS='.' read -r -a VERSION_PARTS <<< "$LATEST_VERSION"
+          # Increment patch version
           NEXT_PATCH=$((VERSION_PARTS[2] + 1))
+          # Construct next version string
           NEXT_VERSION="v${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.$NEXT_PATCH"
           echo "Latest tag: $LATEST_TAG"
           echo "Next version: $NEXT_VERSION"
+          # Set output for subsequent steps
           echo "next_version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Create Tag and Release
+      - name: Create Tag
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEXT_VERSION: ${{ steps.version.outputs.next_version }}
         run: |
           git tag "$NEXT_VERSION"
           git push origin "$NEXT_VERSION"
-          gh release create "$NEXT_VERSION" \
-            --title "$NEXT_VERSION" \
-            --generate-notes
+          echo "Created and pushed tag $NEXT_VERSION"
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.next_version }}
+        run: |
+          gh release create "$TAG" \
+            --title "Release $TAG" \
+            --generate-notes \
+            --verify-tag


### PR DESCRIPTION
### What does this PR do?

Aligns the `auto-release.yaml` workflow with the pattern used in `mcp-oauth` and other Giant Swarm Go libraries.

### Changes

- Split combined "Create Tag and Release" into separate "Create Tag" and "Create GitHub Release" steps -- cleaner failure handling and easier debugging
- Add `--verify-tag` flag to `gh release create` for safety
- Use "Release vX.Y.Z" title format for consistency across repos
- Add inline comments explaining each step

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)

Made with [Cursor](https://cursor.com)