### PR TITLE
Add Client.ListRepositories for registry catalog discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Client.ListRepositories` method for discovering OCI repositories under a registry base path via the catalog API, enabling remote artifact discovery without local cache.
+- `SplitRegistryBase` helper for parsing registry base paths into host and prefix components.
 - Initial release of shared OCI types and ORAS client for Klaus artifacts.
 - Media type constants for plugin and personality artifacts.
 - `PluginMeta`, `PersonalityMeta`, and `PersonalitySpec` types.

--- a/helpers.go
+++ b/helpers.go
@@ -2,6 +2,19 @@ package oci
 
 import "strings"
 
+// SplitRegistryBase splits a registry base path into the registry host and
+// the repository name prefix (with trailing slash). For example,
+// "gsoci.azurecr.io/giantswarm/klaus-plugins" returns
+// ("gsoci.azurecr.io", "giantswarm/klaus-plugins/").
+// If the base contains no slash, the prefix is empty (matches all repositories).
+func SplitRegistryBase(base string) (host, prefix string) {
+	idx := strings.Index(base, "/")
+	if idx < 0 {
+		return base, ""
+	}
+	return base[:idx], base[idx+1:] + "/"
+}
+
 // ShortName extracts the last segment of a repository path.
 // For example, "gsoci.azurecr.io/giantswarm/klaus-plugins/gs-platform" returns "gs-platform".
 func ShortName(repository string) string {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -2,6 +2,32 @@ package oci
 
 import "testing"
 
+func TestSplitRegistryBase(t *testing.T) {
+	tests := []struct {
+		base       string
+		wantHost   string
+		wantPrefix string
+	}{
+		{"gsoci.azurecr.io/giantswarm/klaus-plugins", "gsoci.azurecr.io", "giantswarm/klaus-plugins/"},
+		{"gsoci.azurecr.io/giantswarm/klaus-personalities", "gsoci.azurecr.io", "giantswarm/klaus-personalities/"},
+		{"gsoci.azurecr.io", "gsoci.azurecr.io", ""},
+		{"localhost:5000/plugins", "localhost:5000", "plugins/"},
+		{"example.com/org/team/artifacts", "example.com", "org/team/artifacts/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.base, func(t *testing.T) {
+			gotHost, gotPrefix := SplitRegistryBase(tt.base)
+			if gotHost != tt.wantHost {
+				t.Errorf("host = %q, want %q", gotHost, tt.wantHost)
+			}
+			if gotPrefix != tt.wantPrefix {
+				t.Errorf("prefix = %q, want %q", gotPrefix, tt.wantPrefix)
+			}
+		})
+	}
+}
+
 func TestShortName(t *testing.T) {
 	tests := []struct {
 		repository string


### PR DESCRIPTION
## Summary

- Adds `Client.ListRepositories(ctx, registryBase)` method that queries the OCI registry catalog API and returns repositories matching a base path prefix (e.g., all repos under `gsoci.azurecr.io/giantswarm/klaus-plugins/`).
- Exports `SplitRegistryBase` helper for parsing registry base paths into host and prefix components.
- Needed by klausctl to fix `plugin list --remote` and `personality list --remote` failing without local cache (giantswarm/klausctl#42).

## Test plan

- [x] Unit tests for `SplitRegistryBase` added
- [x] `go test ./...` passes
- [x] `go vet ./...` clean


Made with [Cursor](https://cursor.com)