### PR TITLE
feat: add stale-while-revalidate registry response cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,58 @@ for _, w := range deps.Warnings {
 }
 ```
 
+### Registry response cache
+
+Network roundtrips dominate the latency of `Describe*`, `Resolve*Ref`, and
+`List*Versions`. Enable the on-disk cache to make repeated invocations fast:
+
+```go
+client := oci.NewClient(
+    oci.WithCache("/var/cache/klaus/oci"),
+    oci.WithCacheTTL(30*time.Second, 24*time.Hour),
+    oci.WithCacheMaxSize(2*1024*1024*1024),
+    oci.WithBackgroundRefresh(true),
+)
+defer client.CloseCache()
+```
+
+The cache is **stale-while-revalidate** with digest-based invalidation:
+
+- **Fresh TTL** (default 30s): entries are returned without contacting the
+  registry.
+- **Stale TTL** (default 24h for tags/refs, 7 days for the catalog): entries
+  past the fresh window are returned immediately *and* a background refresh
+  is issued. HEAD probes on refs use `Docker-Content-Digest`; tag and catalog
+  lists use conditional GETs (`If-None-Match` / `ETag`).
+- **Past stale TTL**: the next call refetches synchronously.
+- **HEAD/digest mismatch**: when a HEAD returns a new digest, the ref entry
+  is rewritten so subsequent reads see the updated manifest.
+
+Concurrent misses for the same key coalesce via singleflight, so a burst of
+parallel `Resolve` calls produces a single registry request.
+
+#### On-disk layout
+
+```
+<root>/
+  blobs/                 # oras-go content store (content-addressed)
+    sha256/aa/bb.../...
+  refs/<sha256-of-key>.json    # tag -> digest index (per full ref)
+  tags/<sha256-of-key>.json    # tag list per repository
+  catalog/<sha256-of-key>.json # catalog per registry base
+```
+
+JSON indexes are written via temp-file + `rename` in the same directory, so
+concurrent writers never observe partial files. The content store is an LRU
+(by mtime) bounded by `WithCacheMaxSize`; a non-positive size disables
+eviction.
+
+If caching is not configured (no `WithCache`), the client behaves exactly
+as before. This cache is orthogonal to the per-destination
+`.oci-cache.json` written by `PullPersonality` / `PullPlugin`, which
+remains the authority for "is this artifact already extracted at this
+path".
+
 ## Artifact Types
 
 Klaus has three artifact types with different OCI representations:

--- a/client.go
+++ b/client.go
@@ -4,8 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
+	"sync"
+	"time"
 
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 )
@@ -16,6 +20,15 @@ type Client struct {
 	plainHTTP   bool
 	authClient  *auth.Client
 	concurrency int
+
+	// cache configuration captured from WithCache*. The store itself is
+	// created lazily on first use so construction errors surface on the
+	// first cache-using call rather than forcing NewClient to change
+	// signature.
+	cacheCfg  cacheConfig
+	storeOnce sync.Once
+	store     CacheStore
+	storeErr  error
 }
 
 const defaultConcurrency = 10
@@ -49,11 +62,48 @@ func WithRegistryAuthEnv(envName string) ClientOption {
 	}
 }
 
+// WithCache enables the on-disk registry response cache rooted at dir.
+// The cache accelerates tag resolves, tag lists, catalog lookups, and
+// manifest/blob fetches. See CacheStore for invalidation details. An
+// empty dir leaves the cache disabled.
+func WithCache(dir string) ClientOption {
+	return func(c *Client) { c.cacheCfg.dir = dir }
+}
+
+// WithCacheTTL overrides the default fresh and stale TTLs for reference
+// and tag-list entries. The catalog TTL is not affected. A non-positive
+// value keeps the default for that field.
+func WithCacheTTL(fresh, stale time.Duration) ClientOption {
+	return func(c *Client) {
+		if fresh > 0 {
+			c.cacheCfg.freshTTL = fresh
+		}
+		if stale > 0 {
+			c.cacheCfg.staleTTL = stale
+		}
+	}
+}
+
+// WithCacheMaxSize overrides the default LRU budget (bytes) for the
+// content store. A non-positive value disables eviction.
+func WithCacheMaxSize(bytes int64) ClientOption {
+	return func(c *Client) { c.cacheCfg.maxBytes = bytes }
+}
+
+// WithBackgroundRefresh toggles async revalidation of stale-but-usable
+// cache entries. Default on. When off, stale entries still return
+// immediately but no background probe is issued; the entry is refetched
+// synchronously only when it ages past the stale TTL.
+func WithBackgroundRefresh(enabled bool) ClientOption {
+	return func(c *Client) { c.cacheCfg.backgroundRefresh = enabled }
+}
+
 // NewClient creates a new OCI client for Klaus artifacts.
 func NewClient(opts ...ClientOption) *Client {
 	c := &Client{
 		authClient:  newAuthClient(""),
 		concurrency: defaultConcurrency,
+		cacheCfg:    defaultCacheConfig(),
 	}
 	for _, o := range opts {
 		o(c)
@@ -61,28 +111,73 @@ func NewClient(opts ...ClientOption) *Client {
 	return c
 }
 
+// cacheStore returns the lazily-initialised cache store, or (nil, nil) when
+// caching is not configured.
+func (c *Client) cacheStore() (CacheStore, error) {
+	if c.cacheCfg.dir == "" {
+		return nil, nil
+	}
+	c.storeOnce.Do(func() {
+		c.store, c.storeErr = newDiskCache(c.cacheCfg, c.authClient, c.plainHTTP)
+	})
+	return c.store, c.storeErr
+}
+
+// CloseCache releases any cache resources held by the client. It is safe
+// to call even when no cache was configured.
+func (c *Client) CloseCache() error {
+	store, err := c.cacheStore()
+	if err != nil || store == nil {
+		return err
+	}
+	return store.Close()
+}
+
 // Resolve resolves a reference (tag or digest) to its manifest digest.
 func (c *Client) Resolve(ctx context.Context, ref string) (string, error) {
+	if hasDigest(ref) {
+		return digestFromRef(ref), nil
+	}
+
+	store, err := c.cacheStore()
+	if err != nil {
+		return "", err
+	}
+	if store != nil {
+		if digest, cerr := store.ResolveTag(ctx, ref); cerr == nil {
+			return digest, nil
+		}
+		// Cache failed: fall through to the uncached path rather than
+		// propagating cache errors to callers.
+	}
+
 	repo, tag, err := c.newRepository(ref)
 	if err != nil {
 		return "", err
 	}
-
 	if tag == "" {
 		return "", fmt.Errorf("reference %q must include a tag or digest", ref)
 	}
-
 	desc, err := repo.Resolve(ctx, tag)
 	if err != nil {
 		return "", fmt.Errorf("resolving %s: %w", ref, err)
 	}
-
 	return desc.Digest.String(), nil
 }
 
 // listRepositories queries the OCI registry catalog to find all repositories
 // under the given base path.
 func (c *Client) listRepositories(ctx context.Context, registryBase string) ([]string, error) {
+	store, err := c.cacheStore()
+	if err != nil {
+		return nil, err
+	}
+	if store != nil {
+		if repos, cerr := store.Repositories(ctx, registryBase); cerr == nil {
+			return repos, nil
+		}
+	}
+
 	host, prefix := SplitRegistryBase(registryBase)
 
 	reg, err := remote.NewRegistry(host)
@@ -124,6 +219,16 @@ var errStopIteration = errors.New("stop iteration")
 
 // List returns all tags in the given repository.
 func (c *Client) List(ctx context.Context, repository string) ([]string, error) {
+	store, err := c.cacheStore()
+	if err != nil {
+		return nil, err
+	}
+	if store != nil {
+		if tags, cerr := store.Tags(ctx, repository); cerr == nil {
+			return tags, nil
+		}
+	}
+
 	repo, err := c.newRepositoryFromName(repository)
 	if err != nil {
 		return nil, err
@@ -139,6 +244,34 @@ func (c *Client) List(ctx context.Context, repository string) ([]string, error) 
 	}
 
 	return tags, nil
+}
+
+// fetchWithStore fetches a manifest or blob through the cache store when
+// configured, falling back to a direct registry fetch on miss or error.
+// repoName is the "host/repo" path used to satisfy a cache miss.
+func (c *Client) fetchWithStore(ctx context.Context, repo *remote.Repository, repoName string, desc ocispec.Descriptor) (io.ReadCloser, error) {
+	store, err := c.cacheStore()
+	if err == nil && store != nil {
+		if rc, cerr := store.Fetch(ctx, repoName, desc); cerr == nil {
+			return rc, nil
+		}
+	}
+	return repo.Fetch(ctx, desc)
+}
+
+// resolveDescriptor returns the manifest descriptor for ref. When a cache
+// store is configured it is consulted first, and its ResolveManifest
+// result carries enough information (size, media type) for the content
+// store's verified Push path. Cache errors fall back to the registry via
+// the oras-go repository's Resolve (a HEAD).
+func (c *Client) resolveDescriptor(ctx context.Context, repo *remote.Repository, ref, tag string) (ocispec.Descriptor, error) {
+	store, err := c.cacheStore()
+	if err == nil && store != nil {
+		if desc, cerr := store.ResolveManifest(ctx, ref); cerr == nil {
+			return desc, nil
+		}
+	}
+	return repo.Resolve(ctx, tag)
 }
 
 // newRepository creates a remote.Repository from a full OCI reference string

--- a/pull.go
+++ b/pull.go
@@ -27,7 +27,7 @@ func (c *Client) pull(ctx context.Context, ref string, destDir string, kind arti
 		return nil, fmt.Errorf("reference %q must include a tag or digest", ref)
 	}
 
-	manifestDesc, err := repo.Resolve(ctx, tag)
+	manifestDesc, err := c.resolveDescriptor(ctx, repo, ref, tag)
 	if err != nil {
 		return nil, fmt.Errorf("resolving %s: %w", ref, err)
 	}
@@ -46,7 +46,9 @@ func (c *Client) pull(ctx context.Context, ref string, destDir string, kind arti
 		return &pullResult{Digest: digest, Ref: ref, Cached: true, ConfigJSON: configJSON, Annotations: annotations}, nil
 	}
 
-	manifestRC, err := repo.Fetch(ctx, manifestDesc)
+	repoName := RepositoryFromRef(ref)
+
+	manifestRC, err := c.fetchWithStore(ctx, repo, repoName, manifestDesc)
 	if err != nil {
 		return nil, fmt.Errorf("fetching manifest for %s: %w", ref, err)
 	}
@@ -57,7 +59,7 @@ func (c *Client) pull(ctx context.Context, ref string, destDir string, kind arti
 		return nil, fmt.Errorf("parsing manifest for %s: %w", ref, err)
 	}
 
-	configRC, err := repo.Fetch(ctx, manifest.Config)
+	configRC, err := c.fetchWithStore(ctx, repo, repoName, manifest.Config)
 	if err != nil {
 		return nil, fmt.Errorf("fetching config for %s: %w", ref, err)
 	}
@@ -78,7 +80,7 @@ func (c *Client) pull(ctx context.Context, ref string, destDir string, kind arti
 		return nil, fmt.Errorf("no content layer found in %s (expected media type %s)", ref, kind.ContentMediaType)
 	}
 
-	layerRC, err := repo.Fetch(ctx, *contentLayer)
+	layerRC, err := c.fetchWithStore(ctx, repo, repoName, *contentLayer)
 	if err != nil {
 		return nil, fmt.Errorf("fetching content layer for %s: %w", ref, err)
 	}

--- a/store.go
+++ b/store.go
@@ -1,0 +1,89 @@
+package oci
+
+import (
+	"context"
+	"io"
+	"time"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// Default TTLs and size limit for the on-disk cache. Exposed as constants so
+// callers can reason about cache behavior.
+const (
+	// DefaultCacheFreshTTL is the window within which a cache entry is
+	// returned with zero network traffic.
+	DefaultCacheFreshTTL = 30 * time.Second
+	// DefaultCacheStaleTTL is the default outer bound for tag and reference
+	// entries: beyond this age the entry is discarded and refetched
+	// synchronously.
+	DefaultCacheStaleTTL = 24 * time.Hour
+	// DefaultCacheCatalogStaleTTL is the outer bound for catalog entries.
+	// Registry catalogs change slowly so we keep them much longer.
+	DefaultCacheCatalogStaleTTL = 7 * 24 * time.Hour
+	// DefaultCacheMaxSize is the default LRU budget (bytes) for the content
+	// store.
+	DefaultCacheMaxSize int64 = 2 * 1024 * 1024 * 1024
+)
+
+// CacheStore provides cached lookups against an OCI registry.
+//
+// When a CacheStore is attached to a Client via WithCache, every read path
+// (tag resolve, tag list, repository catalog, manifest/blob fetch) consults
+// the store first and falls back to the network on miss. The store is a
+// pure cache: it never serves stale data that contradicts the registry,
+// only data that is either fresh or known-good-pending-revalidation.
+//
+// Implementations must be safe for concurrent use, and must be safe to use
+// across concurrent processes sharing the same backing directory.
+type CacheStore interface {
+	// ResolveTag returns the manifest digest for a tag reference of the form
+	// "host/repo:tag". Entries are revalidated with HEAD probes against the
+	// registry.
+	ResolveTag(ctx context.Context, ref string) (string, error)
+
+	// ResolveManifest returns the full manifest descriptor (digest, size,
+	// media type) for a tag reference. Callers that plan to fetch the
+	// manifest body should use this method rather than ResolveTag so the
+	// returned descriptor carries enough information for downstream
+	// verification.
+	ResolveManifest(ctx context.Context, ref string) (ocispec.Descriptor, error)
+
+	// Tags returns all tags for a repository of the form "host/repo". Tag
+	// lists are revalidated with conditional GETs (If-None-Match).
+	Tags(ctx context.Context, repo string) ([]string, error)
+
+	// Repositories returns all repositories under a registry base of the
+	// form "host/prefix". Empty prefixes enumerate the whole registry.
+	Repositories(ctx context.Context, base string) ([]string, error)
+
+	// Fetch returns a reader for the content of desc. The content is served
+	// from the local content store when present; otherwise it is fetched
+	// from the registry and inserted into the store before returning.
+	Fetch(ctx context.Context, repo string, desc ocispec.Descriptor) (io.ReadCloser, error)
+
+	// Close releases resources. It waits for any in-flight background
+	// revalidations to complete.
+	Close() error
+}
+
+// cacheConfig holds the tunable parameters for the on-disk cache. It is
+// populated by WithCache*, and passed to newDiskCache during lazy init.
+type cacheConfig struct {
+	dir               string
+	freshTTL          time.Duration
+	staleTTL          time.Duration
+	catalogStaleTTL   time.Duration
+	maxBytes          int64
+	backgroundRefresh bool
+}
+
+func defaultCacheConfig() cacheConfig {
+	return cacheConfig{
+		freshTTL:          DefaultCacheFreshTTL,
+		staleTTL:          DefaultCacheStaleTTL,
+		catalogStaleTTL:   DefaultCacheCatalogStaleTTL,
+		maxBytes:          DefaultCacheMaxSize,
+		backgroundRefresh: true,
+	}
+}

--- a/store_disk.go
+++ b/store_disk.go
@@ -1,0 +1,609 @@
+package oci
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/singleflight"
+	orasoci "oras.land/oras-go/v2/content/oci"
+	"oras.land/oras-go/v2/registry/remote/auth"
+)
+
+// ocispecDigest narrows a digest string into a go-digest.Digest without
+// validating. Callers that need validation should use digest.Digest.Validate.
+func ocispecDigest(s string) digest.Digest {
+	return digest.Digest(s)
+}
+
+// diskCache implements CacheStore with a directory rooted at cfg.dir.
+//
+// Layout on disk:
+//
+//	<root>/blobs/     -- layer A, oci-layout content store (oras-go)
+//	<root>/refs/      -- layer B, per-tag digest index (hashed filenames)
+//	<root>/tags/      -- layer C, per-repo tag list with ETag
+//	<root>/catalog/   -- layer D, per-base repository catalog
+//
+// Index layers are written via temp+rename for multi-process safety.
+type diskCache struct {
+	cfg        cacheConfig
+	authClient *auth.Client
+	plainHTTP  bool
+	storage    *orasoci.Storage
+
+	sf singleflight.Group
+
+	bg     sync.WaitGroup
+	closed atomic.Bool
+}
+
+// Index entry shapes. `Key` is repeated inside the file so a reader can
+// verify the entry belongs to the expected query (defense in depth against
+// hash collisions or tampered files).
+
+type refIndexEntry struct {
+	Key       string    `json:"key"`
+	Digest    string    `json:"digest"`
+	Size      int64     `json:"size,omitempty"`
+	MediaType string    `json:"media_type,omitempty"`
+	ETag      string    `json:"etag,omitempty"`
+	FetchedAt time.Time `json:"fetched_at"`
+}
+
+type tagIndexEntry struct {
+	Key       string    `json:"key"`
+	Tags      []string  `json:"tags"`
+	ETag      string    `json:"etag,omitempty"`
+	FetchedAt time.Time `json:"fetched_at"`
+}
+
+type catalogIndexEntry struct {
+	Key       string    `json:"key"`
+	Repos     []string  `json:"repos"`
+	FetchedAt time.Time `json:"fetched_at"`
+}
+
+func newDiskCache(cfg cacheConfig, authClient *auth.Client, plainHTTP bool) (*diskCache, error) {
+	if cfg.dir == "" {
+		return nil, errors.New("cache directory required")
+	}
+	for _, sub := range []string{"blobs", "refs", "tags", "catalog"} {
+		if err := os.MkdirAll(filepath.Join(cfg.dir, sub), 0o755); err != nil {
+			return nil, fmt.Errorf("cache setup: %w", err)
+		}
+	}
+	storage, err := orasoci.NewStorage(filepath.Join(cfg.dir, "blobs"))
+	if err != nil {
+		return nil, fmt.Errorf("creating blob storage: %w", err)
+	}
+	return &diskCache{
+		cfg:        cfg,
+		authClient: authClient,
+		plainHTTP:  plainHTTP,
+		storage:    storage,
+	}, nil
+}
+
+// Close waits for in-flight background work to finish. Safe to call more
+// than once.
+func (d *diskCache) Close() error {
+	if d.closed.Swap(true) {
+		return nil
+	}
+	d.bg.Wait()
+	return nil
+}
+
+// ResolveTag looks up the manifest digest for a tag reference, consulting
+// the reference index (layer B) and falling back to a HEAD probe.
+func (d *diskCache) ResolveTag(ctx context.Context, ref string) (string, error) {
+	desc, err := d.ResolveManifest(ctx, ref)
+	if err != nil {
+		return "", err
+	}
+	return desc.Digest.String(), nil
+}
+
+// ResolveManifest returns the full manifest descriptor for a tag reference,
+// including size and media type captured from the HEAD response. Falls back
+// to an entry with a synthetic descriptor if the ref contains a digest.
+func (d *diskCache) ResolveManifest(ctx context.Context, ref string) (ocispec.Descriptor, error) {
+	if strings.Contains(ref, "@") {
+		dgst := digest.Digest(digestFromRef(ref))
+		if err := dgst.Validate(); err != nil {
+			return ocispec.Descriptor{}, fmt.Errorf("cache: invalid digest in %q: %w", ref, err)
+		}
+		return ocispec.Descriptor{
+			Digest:    dgst,
+			MediaType: ocispec.MediaTypeImageManifest,
+		}, nil
+	}
+	host, repo, tag, err := splitFullRef(ref)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	key := host + "/" + repo + ":" + tag
+	path := d.indexPath("refs", key)
+
+	entry, ok := readRefIndex(path)
+	if ok && entry.Key == key {
+		age := time.Since(entry.FetchedAt)
+		if age < d.cfg.freshTTL {
+			return descriptorFromRefEntry(entry), nil
+		}
+		if age < d.cfg.staleTTL {
+			d.maybeRevalidateRef(ctx, host, repo, tag, key, path, entry)
+			return descriptorFromRefEntry(entry), nil
+		}
+	}
+
+	v, err, _ := d.sf.Do("ref:"+key, func() (any, error) {
+		desc, etag, err := d.probeTag(ctx, host, repo, tag, "")
+		if err != nil {
+			return nil, err
+		}
+		next := refIndexEntry{
+			Key:       key,
+			Digest:    desc.Digest.String(),
+			Size:      desc.Size,
+			MediaType: desc.MediaType,
+			ETag:      etag,
+			FetchedAt: time.Now(),
+		}
+		_ = writeIndexAtomic(path, next)
+		return desc, nil
+	})
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	return v.(ocispec.Descriptor), nil
+}
+
+// descriptorFromRefEntry builds a descriptor from an index entry, defaulting
+// the media type to OCI manifest when the entry predates media-type storage.
+func descriptorFromRefEntry(e refIndexEntry) ocispec.Descriptor {
+	mt := e.MediaType
+	if mt == "" {
+		mt = ocispec.MediaTypeImageManifest
+	}
+	return ocispec.Descriptor{
+		Digest:    ocispecDigest(e.Digest),
+		Size:      e.Size,
+		MediaType: mt,
+	}
+}
+
+// Tags returns the cached tag list for a repository, refreshing with a
+// conditional GET when stale.
+func (d *diskCache) Tags(ctx context.Context, repo string) ([]string, error) {
+	host, name := splitHostPath(repo)
+	if host == "" || name == "" {
+		return nil, fmt.Errorf("cache: invalid repository %q", repo)
+	}
+	key := host + "/" + name
+	path := d.indexPath("tags", key)
+
+	entry, ok := readTagIndex(path)
+	if ok && entry.Key == key {
+		age := time.Since(entry.FetchedAt)
+		if age < d.cfg.freshTTL {
+			return append([]string(nil), entry.Tags...), nil
+		}
+		if age < d.cfg.staleTTL {
+			d.maybeRevalidateTags(ctx, host, name, key, path, entry)
+			return append([]string(nil), entry.Tags...), nil
+		}
+	}
+
+	v, err, _ := d.sf.Do("tags:"+key, func() (any, error) {
+		var prevETag string
+		if ok {
+			prevETag = entry.ETag
+		}
+		tags, newETag, notModified, err := d.fetchTags(ctx, host, name, prevETag)
+		if err != nil {
+			return nil, err
+		}
+		if notModified && ok {
+			next := entry
+			next.FetchedAt = time.Now()
+			_ = writeIndexAtomic(path, next)
+			return append([]string(nil), entry.Tags...), nil
+		}
+		next := tagIndexEntry{Key: key, Tags: tags, ETag: newETag, FetchedAt: time.Now()}
+		_ = writeIndexAtomic(path, next)
+		return append([]string(nil), tags...), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.([]string), nil
+}
+
+// Repositories returns the cached catalog for a registry base.
+func (d *diskCache) Repositories(ctx context.Context, base string) ([]string, error) {
+	host, prefix := splitHostPath(base)
+	if host == "" {
+		return nil, fmt.Errorf("cache: invalid base %q", base)
+	}
+	key := host + "/" + prefix
+	path := d.indexPath("catalog", key)
+
+	entry, ok := readCatalogIndex(path)
+	if ok && entry.Key == key {
+		age := time.Since(entry.FetchedAt)
+		if age < d.cfg.freshTTL {
+			return append([]string(nil), entry.Repos...), nil
+		}
+		if age < d.cfg.catalogStaleTTL {
+			d.maybeRevalidateCatalog(ctx, host, prefix, key, path)
+			return append([]string(nil), entry.Repos...), nil
+		}
+	}
+
+	v, err, _ := d.sf.Do("catalog:"+key, func() (any, error) {
+		repos, err := d.fetchCatalog(ctx, host, prefix)
+		if err != nil {
+			return nil, err
+		}
+		next := catalogIndexEntry{Key: key, Repos: repos, FetchedAt: time.Now()}
+		_ = writeIndexAtomic(path, next)
+		return append([]string(nil), repos...), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return v.([]string), nil
+}
+
+// maxUnknownSizeBytes bounds in-memory reads when a descriptor's size is
+// unknown. 64 MiB is large enough for any realistic manifest, index, or
+// config blob while preventing unbounded memory growth from a hostile or
+// misbehaving registry.
+const maxUnknownSizeBytes int64 = 64 * 1024 * 1024
+
+// Fetch serves a manifest or blob from the content store. Misses are
+// satisfied by fetching from the registry, verifying the digest, and
+// inserting into the store. Descriptors with an unknown size bypass the
+// content store (oras-go's Push requires exact size for verification)
+// but the response is still digest-verified in process before being
+// returned to the caller.
+func (d *diskCache) Fetch(ctx context.Context, repo string, desc ocispec.Descriptor) (io.ReadCloser, error) {
+	if err := desc.Digest.Validate(); err != nil {
+		return nil, fmt.Errorf("cache: invalid descriptor digest: %w", err)
+	}
+	if desc.Size > 0 {
+		if exists, err := d.storage.Exists(ctx, desc); err == nil && exists {
+			return d.storage.Fetch(ctx, desc)
+		}
+	}
+
+	v, err, _ := d.sf.Do("blob:"+desc.Digest.String(), func() (any, error) {
+		host, name := splitHostPath(repo)
+		if host == "" || name == "" {
+			return nil, fmt.Errorf("cache: invalid repository %q", repo)
+		}
+		rc, err := d.fetchContent(ctx, host, name, desc)
+		if err != nil {
+			return nil, err
+		}
+		defer rc.Close()
+
+		var limit int64
+		if desc.Size > 0 {
+			limit = desc.Size
+		} else {
+			limit = maxUnknownSizeBytes
+		}
+		// Read one byte past the limit so an oversize body fails fast
+		// rather than silently truncating.
+		data, err := io.ReadAll(io.LimitReader(rc, limit+1))
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", desc.Digest, err)
+		}
+		if int64(len(data)) > limit {
+			return nil, fmt.Errorf("cache: content for %s exceeds size limit %d", desc.Digest, limit)
+		}
+		if desc.Size > 0 && int64(len(data)) != desc.Size {
+			return nil, fmt.Errorf("cache: short read for %s: got %d want %d", desc.Digest, len(data), desc.Size)
+		}
+		// Always verify the digest before the bytes leave this function.
+		// The oras-go content store would do this on Push, but we cannot
+		// rely on Push for the unknown-size path.
+		if err := verifyDigest(desc.Digest, data); err != nil {
+			return nil, err
+		}
+		if desc.Size > 0 {
+			pushErr := d.storage.Push(ctx, desc, bytes.NewReader(data))
+			if pushErr != nil && !isAlreadyExists(pushErr) {
+				return nil, fmt.Errorf("storing %s: %w", desc.Digest, pushErr)
+			}
+			d.evictIfNeeded()
+		}
+		return data, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	data := v.([]byte)
+	return io.NopCloser(bytes.NewReader(data)), nil
+}
+
+// verifyDigest returns an error if the sha256 of data does not match d.
+// Only sha256 digests are supported; anything else is rejected.
+func verifyDigest(d digest.Digest, data []byte) error {
+	if d.Algorithm() != digest.SHA256 {
+		return fmt.Errorf("cache: unsupported digest algorithm %q", d.Algorithm())
+	}
+	sum := sha256.Sum256(data)
+	got := digest.NewDigestFromBytes(digest.SHA256, sum[:])
+	if got != d {
+		return fmt.Errorf("cache: digest mismatch: got %s want %s", got, d)
+	}
+	return nil
+}
+
+// --- revalidation helpers ---
+
+func (d *diskCache) maybeRevalidateRef(ctx context.Context, host, repo, tag, key, path string, prev refIndexEntry) {
+	if !d.cfg.backgroundRefresh || d.closed.Load() {
+		return
+	}
+	d.bg.Add(1)
+	go func() {
+		defer d.bg.Done()
+		bgCtx, cancel := detachCtx(ctx, 30*time.Second)
+		defer cancel()
+		_, _, _ = d.sf.Do("ref:"+key, func() (any, error) {
+			desc, etag, err := d.probeTag(bgCtx, host, repo, tag, prev.ETag)
+			if err != nil {
+				return nil, nil
+			}
+			next := refIndexEntry{
+				Key:       key,
+				Digest:    desc.Digest.String(),
+				Size:      desc.Size,
+				MediaType: desc.MediaType,
+				ETag:      etag,
+				FetchedAt: time.Now(),
+			}
+			_ = writeIndexAtomic(path, next)
+			return nil, nil
+		})
+	}()
+}
+
+func (d *diskCache) maybeRevalidateTags(ctx context.Context, host, repo, key, path string, prev tagIndexEntry) {
+	if !d.cfg.backgroundRefresh || d.closed.Load() {
+		return
+	}
+	d.bg.Add(1)
+	go func() {
+		defer d.bg.Done()
+		bgCtx, cancel := detachCtx(ctx, 30*time.Second)
+		defer cancel()
+		_, _, _ = d.sf.Do("tags:"+key, func() (any, error) {
+			tags, etag, notModified, err := d.fetchTags(bgCtx, host, repo, prev.ETag)
+			if err != nil {
+				return nil, nil
+			}
+			if notModified {
+				next := prev
+				next.FetchedAt = time.Now()
+				_ = writeIndexAtomic(path, next)
+				return nil, nil
+			}
+			next := tagIndexEntry{Key: key, Tags: tags, ETag: etag, FetchedAt: time.Now()}
+			_ = writeIndexAtomic(path, next)
+			return nil, nil
+		})
+	}()
+}
+
+func (d *diskCache) maybeRevalidateCatalog(ctx context.Context, host, prefix, key, path string) {
+	if !d.cfg.backgroundRefresh || d.closed.Load() {
+		return
+	}
+	d.bg.Add(1)
+	go func() {
+		defer d.bg.Done()
+		bgCtx, cancel := detachCtx(ctx, 60*time.Second)
+		defer cancel()
+		_, _, _ = d.sf.Do("catalog:"+key, func() (any, error) {
+			repos, err := d.fetchCatalog(bgCtx, host, prefix)
+			if err != nil {
+				return nil, nil
+			}
+			next := catalogIndexEntry{Key: key, Repos: repos, FetchedAt: time.Now()}
+			_ = writeIndexAtomic(path, next)
+			return nil, nil
+		})
+	}()
+}
+
+// --- file layout helpers ---
+
+func (d *diskCache) indexPath(sub, key string) string {
+	sum := sha256.Sum256([]byte(key))
+	name := hex.EncodeToString(sum[:])
+	return filepath.Join(d.cfg.dir, sub, name+".json")
+}
+
+func readRefIndex(path string) (refIndexEntry, bool) {
+	var e refIndexEntry
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return e, false
+	}
+	if err := json.Unmarshal(data, &e); err != nil {
+		return e, false
+	}
+	return e, true
+}
+
+func readTagIndex(path string) (tagIndexEntry, bool) {
+	var e tagIndexEntry
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return e, false
+	}
+	if err := json.Unmarshal(data, &e); err != nil {
+		return e, false
+	}
+	return e, true
+}
+
+func readCatalogIndex(path string) (catalogIndexEntry, bool) {
+	var e catalogIndexEntry
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return e, false
+	}
+	if err := json.Unmarshal(data, &e); err != nil {
+		return e, false
+	}
+	return e, true
+}
+
+// writeIndexAtomic serializes v to JSON and writes it to path via a temp
+// file in the same directory followed by os.Rename. Two processes racing
+// on the same path each produce a valid final state -- the later renamer
+// wins.
+func writeIndexAtomic(path string, v any) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	var suffix [8]byte
+	_, _ = rand.Read(suffix[:])
+	tmp := filepath.Join(dir, filepath.Base(path)+".tmp."+hex.EncodeToString(suffix[:]))
+	f, err := os.OpenFile(tmp, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return err
+	}
+	if _, err := f.Write(data); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Sync(); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// --- LRU eviction for the content store ---
+
+type blobInfo struct {
+	path  string
+	size  int64
+	mtime time.Time
+}
+
+// evictIfNeeded walks the blob tree and evicts oldest entries until the
+// total byte count falls within the configured limit. It is a best-effort
+// background operation; it returns no error and swallows filesystem races.
+func (d *diskCache) evictIfNeeded() {
+	limit := d.cfg.maxBytes
+	if limit <= 0 {
+		return
+	}
+	root := filepath.Join(d.cfg.dir, "blobs", "sha256")
+	var blobs []blobInfo
+	var total int64
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		blobs = append(blobs, blobInfo{path: path, size: info.Size(), mtime: info.ModTime()})
+		total += info.Size()
+		return nil
+	})
+	if total <= limit {
+		return
+	}
+	sort.Slice(blobs, func(i, j int) bool { return blobs[i].mtime.Before(blobs[j].mtime) })
+	for _, b := range blobs {
+		if total <= limit {
+			return
+		}
+		if err := os.Remove(b.path); err == nil {
+			total -= b.size
+		}
+	}
+}
+
+// --- utility helpers ---
+
+// splitHostPath splits "host/path" into host and path. Returns empty path
+// if the input has no slash.
+func splitHostPath(s string) (host, path string) {
+	idx := strings.Index(s, "/")
+	if idx < 0 {
+		return s, ""
+	}
+	return s[:idx], s[idx+1:]
+}
+
+// splitFullRef splits "host/repo:tag" into host, repo, tag. Returns an
+// error if the ref does not contain a tag.
+func splitFullRef(ref string) (host, repo, tag string, err error) {
+	h, rest := splitHostPath(ref)
+	if h == "" || rest == "" {
+		return "", "", "", fmt.Errorf("cache: invalid reference %q", ref)
+	}
+	idx := strings.LastIndex(rest, ":")
+	if idx < 0 {
+		return "", "", "", fmt.Errorf("cache: reference %q missing tag", ref)
+	}
+	return h, rest[:idx], rest[idx+1:], nil
+}
+
+func digestFromRef(ref string) string {
+	idx := strings.Index(ref, "@")
+	if idx < 0 {
+		return ""
+	}
+	return ref[idx+1:]
+}
+
+// detachCtx returns a fresh background context bounded by timeout. Used
+// for background revalidation so in-flight refreshes are not cancelled
+// when the caller's (typically request-scoped) context ends.
+func detachCtx(_ context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), timeout)
+}
+
+func isAlreadyExists(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "already exists")
+}

--- a/store_http.go
+++ b/store_http.go
@@ -1,0 +1,281 @@
+package oci
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// Known OCI manifest media types. Used to decide whether to fetch via
+// /v2/{repo}/manifests/<digest> or /v2/{repo}/blobs/<digest>. Extend here
+// if new manifest shapes appear.
+var manifestMediaTypes = map[string]struct{}{
+	ocispec.MediaTypeImageManifest:                              {},
+	ocispec.MediaTypeImageIndex:                                 {},
+	"application/vnd.docker.distribution.manifest.v2+json":      {},
+	"application/vnd.docker.distribution.manifest.list.v2+json": {},
+	"application/vnd.docker.distribution.manifest.v1+json":      {},
+	"application/vnd.docker.distribution.manifest.v1+prettyjws": {},
+}
+
+func isManifestMediaType(mt string) bool {
+	_, ok := manifestMediaTypes[mt]
+	return ok
+}
+
+func (d *diskCache) scheme() string {
+	if d.plainHTTP {
+		return "http"
+	}
+	return "https"
+}
+
+// probeTag issues HEAD /v2/{repo}/manifests/{tag} and captures digest,
+// size and media type from the response headers. ifNoneMatch is a hint
+// for registries that support ETag on manifest HEADs; most do not, so
+// it is best effort.
+func (d *diskCache) probeTag(ctx context.Context, host, repo, tag, ifNoneMatch string) (ocispec.Descriptor, string, error) {
+	u := fmt.Sprintf("%s://%s/v2/%s/manifests/%s", d.scheme(), host, repo, url.PathEscape(tag))
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, u, nil)
+	if err != nil {
+		return ocispec.Descriptor{}, "", err
+	}
+	// Prefer OCI manifests, but fall back to docker manifests for older
+	// registries.
+	req.Header.Set("Accept", strings.Join([]string{
+		ocispec.MediaTypeImageManifest,
+		ocispec.MediaTypeImageIndex,
+		"application/vnd.docker.distribution.manifest.v2+json",
+		"application/vnd.docker.distribution.manifest.list.v2+json",
+	}, ", "))
+	if ifNoneMatch != "" {
+		req.Header.Set("If-None-Match", ifNoneMatch)
+	}
+	resp, err := d.authClient.Do(req)
+	if err != nil {
+		return ocispec.Descriptor{}, "", fmt.Errorf("HEAD %s: %w", u, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotModified {
+		return ocispec.Descriptor{}, "", fmt.Errorf("HEAD %s: unexpected status %s", u, resp.Status)
+	}
+	dcd := resp.Header.Get("Docker-Content-Digest")
+	if dcd == "" {
+		return ocispec.Descriptor{}, "", fmt.Errorf("HEAD %s: missing Docker-Content-Digest", u)
+	}
+	dgst := digest.Digest(dcd)
+	if err := dgst.Validate(); err != nil {
+		return ocispec.Descriptor{}, "", fmt.Errorf("HEAD %s: invalid Docker-Content-Digest: %w", u, err)
+	}
+	mediaType := parseContentType(resp.Header.Get("Content-Type"))
+	if !isManifestMediaType(mediaType) {
+		// Either the server returned an unexpected/generic Content-Type
+		// (e.g. "application/json") or one we do not recognise. Fall
+		// back to the OCI manifest type; we only accept allowlisted
+		// types so an arbitrary server header cannot steer us toward
+		// the /blobs/ path in fetchContent.
+		mediaType = ocispec.MediaTypeImageManifest
+	}
+	size := resp.ContentLength
+	if size < 0 {
+		// Chunked responses (common for some registries) lack a
+		// Content-Length. Leave Size zero so callers treat it as
+		// unknown rather than caching -1 as a permanent fact.
+		size = 0
+	}
+	desc := ocispec.Descriptor{
+		Digest:    dgst,
+		Size:      size,
+		MediaType: mediaType,
+	}
+	return desc, resp.Header.Get("ETag"), nil
+}
+
+// parseContentType returns the media-type portion of a Content-Type header,
+// stripping any parameters (charset, boundary, etc.). Returns "" when the
+// header is empty or malformed.
+func parseContentType(v string) string {
+	if v == "" {
+		return ""
+	}
+	mt, _, err := mime.ParseMediaType(v)
+	if err != nil {
+		return ""
+	}
+	return mt
+}
+
+// fetchTags paginates /v2/{repo}/tags/list. If ifNoneMatch is non-empty,
+// it is sent as If-None-Match on the first page request; a 304 on the
+// first page short-circuits pagination and notModified is true. Later
+// pages are fetched unconditionally.
+func (d *diskCache) fetchTags(ctx context.Context, host, repo, ifNoneMatch string) (tags []string, etag string, notModified bool, err error) {
+	next := fmt.Sprintf("%s://%s/v2/%s/tags/list", d.scheme(), host, repo)
+	first := true
+	for next != "" {
+		req, rerr := http.NewRequestWithContext(ctx, http.MethodGet, next, nil)
+		if rerr != nil {
+			return nil, "", false, rerr
+		}
+		req.Header.Set("Accept", "application/json")
+		if first && ifNoneMatch != "" {
+			req.Header.Set("If-None-Match", ifNoneMatch)
+		}
+		resp, rerr := d.authClient.Do(req)
+		if rerr != nil {
+			return nil, "", false, fmt.Errorf("GET %s: %w", next, rerr)
+		}
+		if first && resp.StatusCode == http.StatusNotModified {
+			resp.Body.Close()
+			return nil, ifNoneMatch, true, nil
+		}
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return nil, "", false, fmt.Errorf("GET %s: unexpected status %s", next, resp.Status)
+		}
+		if first {
+			etag = resp.Header.Get("ETag")
+		}
+		var page struct {
+			Tags []string `json:"tags"`
+		}
+		dec := json.NewDecoder(io.LimitReader(resp.Body, 32*1024*1024))
+		derr := dec.Decode(&page)
+		resp.Body.Close()
+		if derr != nil {
+			return nil, "", false, fmt.Errorf("parsing tag list from %s: %w", next, derr)
+		}
+		tags = append(tags, page.Tags...)
+		next = parseNextLink(resp.Header.Get("Link"), next)
+		first = false
+	}
+	return tags, etag, false, nil
+}
+
+// fetchCatalog paginates /v2/_catalog, filtering to repos sharing the
+// given prefix (with trailing slash). Uses the registry spec's `last`
+// parameter to seek past entries that sort before the prefix.
+func (d *diskCache) fetchCatalog(ctx context.Context, host, prefix string) ([]string, error) {
+	seek := strings.TrimSuffix(prefix, "/")
+	base := fmt.Sprintf("%s://%s/v2/_catalog", d.scheme(), host)
+	next := base
+	if seek != "" {
+		next = base + "?last=" + url.QueryEscape(seek)
+	}
+	var repos []string
+	for next != "" {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, next, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Accept", "application/json")
+		resp, err := d.authClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("GET %s: %w", next, err)
+		}
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return nil, fmt.Errorf("GET %s: unexpected status %s", next, resp.Status)
+		}
+		var page struct {
+			Repositories []string `json:"repositories"`
+		}
+		dec := json.NewDecoder(io.LimitReader(resp.Body, 32*1024*1024))
+		derr := dec.Decode(&page)
+		resp.Body.Close()
+		if derr != nil {
+			return nil, fmt.Errorf("parsing catalog from %s: %w", next, derr)
+		}
+		done := false
+		for _, name := range page.Repositories {
+			if prefix != "" {
+				if !strings.HasPrefix(name, prefix) {
+					if name > prefix {
+						done = true
+						break
+					}
+					continue
+				}
+			}
+			repos = append(repos, host+"/"+name)
+		}
+		if done {
+			break
+		}
+		next = parseNextLink(resp.Header.Get("Link"), next)
+	}
+	return repos, nil
+}
+
+// fetchContent fetches a manifest or blob from the registry by digest.
+func (d *diskCache) fetchContent(ctx context.Context, host, repo string, desc ocispec.Descriptor) (io.ReadCloser, error) {
+	var path string
+	if isManifestMediaType(desc.MediaType) {
+		path = "manifests"
+	} else {
+		path = "blobs"
+	}
+	u := fmt.Sprintf("%s://%s/v2/%s/%s/%s", d.scheme(), host, repo, path, desc.Digest.String())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	if desc.MediaType != "" {
+		req.Header.Set("Accept", desc.MediaType)
+	}
+	resp, err := d.authClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", u, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		// Drain a small portion of the body to free the connection,
+		// but do not surface the response body: some registries echo
+		// request headers (including auth artefacts) in error bodies.
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
+		resp.Body.Close()
+		return nil, fmt.Errorf("GET %s: unexpected status %s", u, resp.Status)
+	}
+	return resp.Body, nil
+}
+
+// parseNextLink parses the rel="next" entry of a distribution-spec Link
+// header. Returns "" if no next page is indicated. The base URL is used
+// to resolve relative references.
+func parseNextLink(header string, base string) string {
+	if header == "" {
+		return ""
+	}
+	for _, part := range strings.Split(header, ",") {
+		part = strings.TrimSpace(part)
+		if !strings.Contains(part, `rel="next"`) {
+			continue
+		}
+		start := strings.Index(part, "<")
+		end := strings.Index(part, ">")
+		if start < 0 || end < 0 || end <= start {
+			continue
+		}
+		raw := part[start+1 : end]
+		link, err := url.Parse(raw)
+		if err != nil {
+			continue
+		}
+		if link.IsAbs() {
+			return link.String()
+		}
+		baseURL, err := url.Parse(base)
+		if err != nil {
+			return ""
+		}
+		return baseURL.ResolveReference(link).String()
+	}
+	return ""
+}

--- a/store_test.go
+++ b/store_test.go
@@ -1,0 +1,617 @@
+package oci
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// cacheRegistry is a minimal OCI distribution API server with optional
+// ETag support for tag listing, HEAD support for manifests, and request
+// counters for testing caching behaviour.
+type cacheRegistry struct {
+	mu sync.Mutex
+
+	// repos maps repo name -> tag -> manifest digest.
+	repos map[string]map[string]string
+	// manifests maps manifest digest -> bytes.
+	manifests map[string][]byte
+	// blobs maps blob digest -> bytes.
+	blobs map[string][]byte
+	// tagListETag maps repo -> current ETag string.
+	tagListETag map[string]string
+	// catalogRepos is the list of all repos in the catalog.
+	catalogRepos []string
+
+	// Request counters by bucket.
+	headCount     atomic.Int64
+	tagsCount     atomic.Int64
+	catalogCount  atomic.Int64
+	manifestCount atomic.Int64
+	blobCount     atomic.Int64
+	// notModCount counts 304 responses actually emitted.
+	notModCount atomic.Int64
+}
+
+func newCacheRegistry() *cacheRegistry {
+	return &cacheRegistry{
+		repos:       map[string]map[string]string{},
+		manifests:   map[string][]byte{},
+		blobs:       map[string][]byte{},
+		tagListETag: map[string]string{},
+	}
+}
+
+func (r *cacheRegistry) addManifest(repo, tag string, body []byte) string {
+	digest := "sha256:" + sum256Hex(body)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.repos[repo] == nil {
+		r.repos[repo] = map[string]string{}
+	}
+	r.repos[repo][tag] = digest
+	r.manifests[digest] = body
+	r.tagListETag[repo] = fmt.Sprintf("%q", sum256Hex([]byte(fmt.Sprintf("%v", r.repos[repo])))[:12])
+	if !contains(r.catalogRepos, repo) {
+		r.catalogRepos = append(r.catalogRepos, repo)
+		sort.Strings(r.catalogRepos)
+	}
+	return digest
+}
+
+func (r *cacheRegistry) addBlob(body []byte) string {
+	digest := "sha256:" + sum256Hex(body)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.blobs[digest] = body
+	return digest
+}
+
+// handler implements the subset of the distribution API the tests need.
+func (r *cacheRegistry) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		path := req.URL.Path
+		switch {
+		case path == "/v2/" || path == "/v2":
+			w.WriteHeader(http.StatusOK)
+			return
+		case path == "/v2/_catalog":
+			r.catalogCount.Add(1)
+			last := req.URL.Query().Get("last")
+			r.mu.Lock()
+			out := []string{}
+			for _, name := range r.catalogRepos {
+				if last == "" || name > last {
+					out = append(out, name)
+				}
+			}
+			r.mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string][]string{"repositories": out})
+			return
+		case strings.HasSuffix(path, "/tags/list"):
+			r.tagsCount.Add(1)
+			repo := strings.TrimPrefix(path, "/v2/")
+			repo = strings.TrimSuffix(repo, "/tags/list")
+			r.mu.Lock()
+			tagMap := r.repos[repo]
+			etag := r.tagListETag[repo]
+			var tags []string
+			for t := range tagMap {
+				tags = append(tags, t)
+			}
+			r.mu.Unlock()
+			sort.Strings(tags)
+			if tagMap == nil {
+				http.NotFound(w, req)
+				return
+			}
+			if match := req.Header.Get("If-None-Match"); match != "" && match == etag {
+				r.notModCount.Add(1)
+				w.Header().Set("ETag", etag)
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("ETag", etag)
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": repo, "tags": tags})
+			return
+		case strings.Contains(path, "/manifests/"):
+			idx := strings.Index(path, "/manifests/")
+			repo := strings.TrimPrefix(path[:idx], "/v2/")
+			ref := path[idx+len("/manifests/"):]
+			r.mu.Lock()
+			tagMap := r.repos[repo]
+			digest := ref
+			if !strings.HasPrefix(ref, "sha256:") {
+				digest = tagMap[ref]
+			}
+			body := r.manifests[digest]
+			r.mu.Unlock()
+			if digest == "" || body == nil {
+				http.NotFound(w, req)
+				return
+			}
+			w.Header().Set("Docker-Content-Digest", digest)
+			w.Header().Set("Content-Type", ocispec.MediaTypeImageManifest)
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
+			if req.Method == http.MethodHead {
+				r.headCount.Add(1)
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			r.manifestCount.Add(1)
+			_, _ = w.Write(body)
+			return
+		case strings.Contains(path, "/blobs/"):
+			idx := strings.Index(path, "/blobs/")
+			digest := path[idx+len("/blobs/"):]
+			r.mu.Lock()
+			body := r.blobs[digest]
+			r.mu.Unlock()
+			if body == nil {
+				http.NotFound(w, req)
+				return
+			}
+			r.blobCount.Add(1)
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Header().Set("Docker-Content-Digest", digest)
+			_, _ = w.Write(body)
+			return
+		}
+		http.NotFound(w, req)
+	})
+}
+
+func sum256Hex(b []byte) string {
+	s := sha256.Sum256(b)
+	return hex.EncodeToString(s[:])
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}
+
+func newCacheTestClient(t *testing.T, reg *cacheRegistry, opts ...ClientOption) (*Client, string, string) {
+	t.Helper()
+	ts := httptest.NewServer(reg.handler())
+	t.Cleanup(ts.Close)
+	host := strings.TrimPrefix(ts.URL, "http://")
+	dir := t.TempDir()
+	allOpts := append([]ClientOption{WithPlainHTTP(true), WithCache(dir)}, opts...)
+	c := NewClient(allOpts...)
+	t.Cleanup(func() { _ = c.CloseCache() })
+	return c, host, dir
+}
+
+// TestCacheHit_NoNetwork verifies that the second call for a fresh entry
+// does no network traffic.
+func TestCacheHit_NoNetwork(t *testing.T) {
+	reg := newCacheRegistry()
+	digest := reg.addManifest("team/hello", "v1.0.0", []byte(`{"manifest":1}`))
+
+	c, host, _ := newCacheTestClient(t, reg)
+	ref := host + "/team/hello:v1.0.0"
+
+	got, err := c.Resolve(context.Background(), ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != digest {
+		t.Fatalf("digest = %q, want %q", got, digest)
+	}
+	firstHead := reg.headCount.Load()
+
+	got, err = c.Resolve(context.Background(), ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != digest {
+		t.Fatalf("digest = %q, want %q", got, digest)
+	}
+	if reg.headCount.Load() != firstHead {
+		t.Errorf("expected no extra HEAD on fresh cache hit, head count %d -> %d", firstHead, reg.headCount.Load())
+	}
+}
+
+// TestStaleWhileRevalidate returns the cached digest immediately and
+// kicks off a background HEAD probe.
+func TestStaleWhileRevalidate(t *testing.T) {
+	reg := newCacheRegistry()
+	digest := reg.addManifest("team/swr", "v1", []byte(`{"manifest":"a"}`))
+
+	// Set a tiny fresh window so the next call is stale-but-usable.
+	c, host, _ := newCacheTestClient(t, reg,
+		WithCacheTTL(1*time.Millisecond, 1*time.Hour))
+
+	ref := host + "/team/swr:v1"
+	if _, err := c.Resolve(context.Background(), ref); err != nil {
+		t.Fatal(err)
+	}
+	firstHead := reg.headCount.Load()
+	time.Sleep(20 * time.Millisecond)
+
+	got, err := c.Resolve(context.Background(), ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != digest {
+		t.Fatalf("digest = %q, want %q", got, digest)
+	}
+
+	// Wait for the background refresh to land.
+	if err := c.CloseCache(); err != nil {
+		t.Fatal(err)
+	}
+	if reg.headCount.Load() <= firstHead {
+		t.Errorf("expected background HEAD probe after stale read: head count %d -> %d", firstHead, reg.headCount.Load())
+	}
+}
+
+// TestTagList_ConditionalGet_NotModified verifies that a stale tag list
+// is refreshed with a conditional GET and the server's 304 is honoured.
+func TestTagList_ConditionalGet_NotModified(t *testing.T) {
+	reg := newCacheRegistry()
+	reg.addManifest("team/cgtags", "v1", []byte(`{"m":1}`))
+	reg.addManifest("team/cgtags", "v2", []byte(`{"m":2}`))
+
+	c, host, _ := newCacheTestClient(t, reg,
+		WithCacheTTL(1*time.Millisecond, 10*time.Millisecond),
+		WithBackgroundRefresh(false))
+
+	repo := host + "/team/cgtags"
+	got, err := c.List(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(got)
+	if len(got) != 2 {
+		t.Fatalf("tags = %v", got)
+	}
+	tagsBefore := reg.tagsCount.Load()
+	notModBefore := reg.notModCount.Load()
+
+	time.Sleep(25 * time.Millisecond)
+	got, err = c.List(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(got)
+	if len(got) != 2 {
+		t.Fatalf("tags after revalidation = %v", got)
+	}
+	if reg.notModCount.Load() <= notModBefore {
+		t.Errorf("expected at least one 304 response: notMod %d -> %d", notModBefore, reg.notModCount.Load())
+	}
+	if reg.tagsCount.Load() <= tagsBefore {
+		t.Errorf("expected a conditional GET to be issued, tags count %d -> %d", tagsBefore, reg.tagsCount.Load())
+	}
+}
+
+// TestTagList_ConditionalGet_Modified verifies that when the tag list
+// changes, the cache is updated with the new list.
+func TestTagList_ConditionalGet_Modified(t *testing.T) {
+	reg := newCacheRegistry()
+	reg.addManifest("team/cgtags2", "v1", []byte(`{"m":1}`))
+
+	c, host, _ := newCacheTestClient(t, reg,
+		WithCacheTTL(1*time.Millisecond, 10*time.Millisecond),
+		WithBackgroundRefresh(false))
+
+	repo := host + "/team/cgtags2"
+	_, err := c.List(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Publish a new tag -- ETag changes server-side.
+	reg.addManifest("team/cgtags2", "v2", []byte(`{"m":2}`))
+
+	time.Sleep(25 * time.Millisecond)
+	got, err := c.List(context.Background(), repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(got)
+	if len(got) != 2 || got[0] != "v1" || got[1] != "v2" {
+		t.Fatalf("tags = %v, want [v1 v2]", got)
+	}
+}
+
+// TestHeadDigestMismatch verifies that when a HEAD probe returns a new
+// digest, the cache updates its reference entry.
+func TestHeadDigestMismatch(t *testing.T) {
+	reg := newCacheRegistry()
+	reg.addManifest("team/mv", "v1", []byte(`{"m":"old"}`))
+
+	c, host, _ := newCacheTestClient(t, reg,
+		WithCacheTTL(1*time.Millisecond, 10*time.Millisecond),
+		WithBackgroundRefresh(false))
+
+	ref := host + "/team/mv:v1"
+	firstDigest, err := c.Resolve(context.Background(), ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Mutate the manifest on the server side (simulates a tag moving).
+	newDigest := reg.addManifest("team/mv", "v1", []byte(`{"m":"new"}`))
+	if newDigest == firstDigest {
+		t.Fatalf("precondition: new digest should differ")
+	}
+
+	time.Sleep(25 * time.Millisecond)
+	got, err := c.Resolve(context.Background(), ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != newDigest {
+		t.Errorf("digest after stale revalidate = %q, want %q", got, newDigest)
+	}
+}
+
+// TestSingleflightCoalescing verifies that concurrent misses for the same
+// key collapse to a single HEAD.
+func TestSingleflightCoalescing(t *testing.T) {
+	reg := newCacheRegistry()
+	reg.addManifest("team/sf", "v1", []byte(`{"m":"sf"}`))
+
+	c, host, _ := newCacheTestClient(t, reg)
+	ref := host + "/team/sf:v1"
+
+	// N concurrent Resolves on an empty cache.
+	const n = 20
+	var wg sync.WaitGroup
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := c.Resolve(context.Background(), ref)
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+	for _, e := range errs {
+		if e != nil {
+			t.Fatalf("concurrent Resolve error: %v", e)
+		}
+	}
+	if got := reg.headCount.Load(); got > int64(n/2) {
+		t.Errorf("HEAD count %d; expected single-flight coalescing to keep it much lower", got)
+	}
+	if got := reg.headCount.Load(); got == 0 {
+		t.Errorf("expected at least one HEAD")
+	}
+}
+
+// TestAtomicWriteConcurrent verifies that multiple writers racing on the
+// same index file all produce a valid final state (one of them wins).
+func TestAtomicWriteConcurrent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "race.json")
+
+	const n = 16
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			entry := refIndexEntry{
+				Key:       "k",
+				Digest:    fmt.Sprintf("sha256:%064d", i),
+				FetchedAt: time.Now(),
+			}
+			if err := writeIndexAtomic(path, entry); err != nil {
+				t.Errorf("write %d: %v", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read final: %v", err)
+	}
+	var final refIndexEntry
+	if err := json.Unmarshal(data, &final); err != nil {
+		t.Fatalf("final file is not valid JSON: %v\n%s", err, string(data))
+	}
+	if final.Key != "k" {
+		t.Errorf("final key = %q, want %q", final.Key, "k")
+	}
+	// No temp files should linger.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") || strings.Contains(e.Name(), ".tmp.") {
+			t.Errorf("lingering temp file: %s", e.Name())
+		}
+	}
+}
+
+// TestContentStoreCachesBlobs verifies that after a blob is fetched once,
+// a second fetch of the same digest is served from the local content store.
+func TestContentStoreCachesBlobs(t *testing.T) {
+	reg := newCacheRegistry()
+	body := []byte("hello world")
+	digest := reg.addBlob(body)
+
+	c, host, _ := newCacheTestClient(t, reg)
+	store, err := c.cacheStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	desc := ocispec.Descriptor{
+		Digest:    ocispecDigest(digest),
+		Size:      int64(len(body)),
+		MediaType: "application/octet-stream",
+	}
+	rc, err := store.Fetch(context.Background(), host+"/team/blob", desc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := io.ReadAll(rc)
+	rc.Close()
+	if string(got) != string(body) {
+		t.Fatalf("blob mismatch: %q vs %q", got, body)
+	}
+	firstBlob := reg.blobCount.Load()
+
+	rc, err = store.Fetch(context.Background(), host+"/team/blob", desc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got2, _ := io.ReadAll(rc)
+	rc.Close()
+	if string(got2) != string(body) {
+		t.Fatal("second fetch content mismatch")
+	}
+	if reg.blobCount.Load() != firstBlob {
+		t.Errorf("expected content store hit: blob count %d -> %d", firstBlob, reg.blobCount.Load())
+	}
+}
+
+// TestFetchDigestMismatchRejected verifies that if a registry returns bytes
+// whose sha256 does not match the requested digest, Fetch rejects them and
+// does not leak the bogus content to callers.
+func TestFetchDigestMismatchRejected(t *testing.T) {
+	reg := newCacheRegistry()
+	// Register a blob under a digest that will not match the body bytes.
+	body := []byte("trustworthy")
+	bogusDigest := "sha256:" + sum256Hex([]byte("something else entirely"))
+	reg.mu.Lock()
+	reg.blobs[bogusDigest] = body
+	reg.mu.Unlock()
+
+	c, host, _ := newCacheTestClient(t, reg)
+	store, err := c.cacheStore()
+	if err != nil {
+		t.Fatal(err)
+	}
+	desc := ocispec.Descriptor{
+		Digest:    ocispecDigest(bogusDigest),
+		Size:      int64(len(body)),
+		MediaType: "application/octet-stream",
+	}
+	_, err = store.Fetch(context.Background(), host+"/team/bogus", desc)
+	if err == nil {
+		t.Fatal("expected digest-mismatch error, got nil")
+	}
+	if !strings.Contains(err.Error(), "digest mismatch") && !strings.Contains(err.Error(), "short read") {
+		t.Errorf("expected digest mismatch / short read error, got: %v", err)
+	}
+}
+
+// TestCatalogCaching verifies that repository catalog listings are served
+// from the cache on repeat calls within the fresh window.
+func TestCatalogCaching(t *testing.T) {
+	reg := newCacheRegistry()
+	reg.addManifest("team/one/alpha", "v1", []byte(`{}`))
+	reg.addManifest("team/one/beta", "v1", []byte(`{}`))
+	reg.addManifest("team/two/gamma", "v1", []byte(`{}`))
+
+	c, host, _ := newCacheTestClient(t, reg)
+	base := host + "/team/one"
+
+	first, err := c.listRepositories(context.Background(), base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first) != 2 {
+		t.Fatalf("first list = %v", first)
+	}
+	firstCatalog := reg.catalogCount.Load()
+
+	second, err := c.listRepositories(context.Background(), base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second) != 2 {
+		t.Fatalf("second list = %v", second)
+	}
+	if reg.catalogCount.Load() != firstCatalog {
+		t.Errorf("expected no catalog roundtrip on fresh cache hit: %d -> %d", firstCatalog, reg.catalogCount.Load())
+	}
+}
+
+// TestFullResolveZeroNetwork simulates a klausctl "resolve personality
+// deps" workflow: the first invocation populates the cache, the second
+// does zero network calls within the fresh window.
+func TestFullResolveZeroNetwork(t *testing.T) {
+	reg := newCacheRegistry()
+	reg.addManifest("team/personas/sre", "v0.1.0", []byte(`{"personality":1}`))
+	reg.addManifest("team/plugins/gs-base", "v1.0.0", []byte(`{"plugin":1}`))
+	reg.addManifest("team/plugins/gs-base", "v1.1.0", []byte(`{"plugin":2}`))
+	reg.addManifest("team/toolchains/go", "v2.0.0", []byte(`{"toolchain":1}`))
+
+	c, host, _ := newCacheTestClient(t, reg)
+	ctx := context.Background()
+
+	// First invocation: cold cache.
+	_, err := c.ResolvePersonalityRef_withBase(ctx, "sre", host+"/team/personas")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.ResolvePluginRef_withBase(ctx, "gs-base", host+"/team/plugins"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.ResolveToolchainRef_withBase(ctx, "go", host+"/team/toolchains"); err != nil {
+		t.Fatal(err)
+	}
+
+	before := reg.tagsCount.Load() + reg.headCount.Load() + reg.catalogCount.Load() + reg.blobCount.Load() + reg.manifestCount.Load()
+
+	// Second invocation: everything must hit the cache.
+	if _, err := c.ResolvePersonalityRef_withBase(ctx, "sre", host+"/team/personas"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.ResolvePluginRef_withBase(ctx, "gs-base", host+"/team/plugins"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := c.ResolveToolchainRef_withBase(ctx, "go", host+"/team/toolchains"); err != nil {
+		t.Fatal(err)
+	}
+
+	after := reg.tagsCount.Load() + reg.headCount.Load() + reg.catalogCount.Load() + reg.blobCount.Load() + reg.manifestCount.Load()
+	if after != before {
+		t.Errorf("expected zero network calls on second invocation within fresh TTL; delta = %d", after-before)
+	}
+}
+
+// ResolvePersonalityRef_withBase / ResolvePluginRef_withBase /
+// ResolveToolchainRef_withBase are test-only conveniences that swap in a
+// custom registry base without changing the public API.
+func (c *Client) ResolvePersonalityRef_withBase(ctx context.Context, ref, base string) (string, error) {
+	return resolveArtifactRef(ctx, c, ref, base)
+}
+
+func (c *Client) ResolvePluginRef_withBase(ctx context.Context, ref, base string) (string, error) {
+	return resolveArtifactRef(ctx, c, ref, base)
+}
+
+func (c *Client) ResolveToolchainRef_withBase(ctx context.Context, ref, base string) (string, error) {
+	return resolveArtifactRef(ctx, c, ref, base)
+}


### PR DESCRIPTION
Closes giantswarm/klaus-oci#25. Companion: giantswarm/klausctl#192.

## Summary

- Four-layer on-disk cache for OCI registry reads: blobs (oras-go content store), ref → digest index, tag-list index, catalog index.
- Stale-while-revalidate with digest-based invalidation: fresh TTL returns zero-network, stale-but-usable TTL returns immediately and kicks off a background refresh, past-stale refetches synchronously.
- HEAD probes with `Docker-Content-Digest` for refs; conditional `If-None-Match` GETs for tag lists; paginated catalog with `last=` seek.
- Singleflight coalescing of concurrent misses for the same key.
- LRU eviction by mtime over a configurable byte budget.
- Atomic index writes via temp + `rename` in the same directory, safe across concurrent writers.
- New client options: `WithCache(dir)`, `WithCacheTTL(fresh, stale)`, `WithCacheMaxSize(bytes)`, `WithBackgroundRefresh(bool)`. `NewClient` signature unchanged; cache init is lazy so construction errors surface on first cache-using call. No behavioural change for callers that don't opt in.

## Security review outcomes

Pre-merge audit flagged several issues that are resolved in this branch:

- In-process sha256 verification on every `Fetch` before bytes leave the cache, including the unknown-size path where oras-go's `Push` verification does not apply.
- Response reads are bounded: by `desc.Size` when known, by a 64 MiB ceiling when not. JSON decoders keep the existing 32 MiB cap.
- `Docker-Content-Digest` header is validated with `digest.Digest.Validate()` before it enters the index.
- `Content-Type` from HEAD is parsed through `mime.ParseMediaType` and allowlisted against known manifest media types; unrecognised values fall back to `application/vnd.oci.image.manifest.v1+json`.
- Negative `Content-Length` (chunked responses) is normalised to unknown-size so the ref entry is not poisoned.
- Registry error bodies are drained but not echoed into returned errors.

## Test plan

- [x] `go test ./...` — all new and existing tests pass locally
- [x] `go vet ./...` clean
- [x] `goimports -local github.com/giantswarm/klaus-oci -w .` clean
- [x] New tests cover: fresh cache hit, stale-while-revalidate, 304 tag-list path, modified tag-list path, HEAD digest mismatch, singleflight coalescing, atomic write under concurrent writers, content-store blob reuse, catalog caching, full personality-resolve with zero network on second invocation, and Fetch rejecting digest-mismatched bytes
- [ ] CircleCI green

README has a new "Registry response cache" section documenting the options and on-disk layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)