### PR TITLE
chore: ignore graphify-out/ knowledge graph artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 
 # OS
 .DS_Store
+
+# graphify knowledge graph (regenerable, rebuilt by the post-commit hook)
+graphify-out/


### PR DESCRIPTION
Adds `graphify-out/` to `.gitignore`. This directory holds a regenerable graphify knowledge graph (graph.json, GRAPH_REPORT.md, graph.html) rebuilt locally by the graphify git hook -- it should not be tracked in git.